### PR TITLE
Support all future pre-1.0 releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "gatsby clean"
   },
   "dependencies": {
-    "@narative/gatsby-theme-novela": "^0.0.9",
+    "@narative/gatsby-theme-novela": "^0.*",
     "gatsby": "^2.13.41",
     "gatsby-plugin-manifest": "^2.2.4",
     "react": "^16.8.6",


### PR DESCRIPTION
This should prevent new blogs created using the starter being locked to outdated theme-version `0.0.9` (as just happened to me).

- Allows everything below 1.0.0, see https://semver.npmjs.com/
- Breaking.*Feature.Fix*