### PR TITLE
Enabled default author page.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -38,6 +38,11 @@ module.exports = {
         contentPosts: "content/posts",
         contentAuthors: "content/authors",
         basePath: "/",
+        authorsPage: true,
+        sources: {
+          local: true,
+          // contentful: true,
+        },
       },
     },
     {


### PR DESCRIPTION
In my case, I'm using the starter to build my site, but I found my author page doesn't enable by default, also I don't find any docs or configs for this problem, and I found the issue:
https://github.com/narative/gatsby-theme-novela/issues/39

It works for `0.2.*`,  but I think it should be enabled by default.